### PR TITLE
iPhoneでも学生証バーコードが表示できるようにする

### DIFF
--- a/script/script.js
+++ b/script/script.js
@@ -49,7 +49,8 @@ function closeSettings(){
 }
 
 function openCard(){
-  document.body.requestFullscreen();
+  let requestFullScreen = document.body.requestFullscreen || document.body.webkitRequestFullscreen;
+  requestFullScreen();
   document.getElementById('card').style.display = 'flex';
 }
 


### PR DESCRIPTION
https://developer.mozilla.org/ja/docs/Web/API/Element/requestFullscreen#%E3%83%96%E3%83%A9%E3%82%A6%E3%82%B6%E3%83%BC%E3%81%AE%E4%BA%92%E6%8F%9B%E6%80%A7

`Element.requestFullscreen`がiPhone上のSafariでは使えないため学生証が表示されない。
`requestFullscreen`が存在しない場合は`webkitRequestFullscreen`を使うようにする。